### PR TITLE
Fix/90 web support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.21.2
+- Observer Widget
+  - Fix web support by @Ahmadre in [#91](https://github.com/LinXunFeng/flutter_scrollview_observer/pull/91)
+
 ## 1.21.1
 - ObserverCore
   - improve the logic of `handleListObserve` and `handleGridObserve`.

--- a/lib/src/common/observer_widget.dart
+++ b/lib/src/common/observer_widget.dart
@@ -4,7 +4,6 @@
  * @Date: 2022-08-08 00:20:03
  */
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -157,7 +156,8 @@ class ObserverWidgetState<
               .contains(notification.runtimeType)) {
             final isIgnoreInnerCanHandleObserve =
                 ScrollUpdateNotification != notification.runtimeType;
-            if (kIsWeb || Platform.isWindows || Platform.isMacOS) {
+            final platform = Theme.of(context).platform;
+            if (kIsWeb || platform == TargetPlatform.windows || platform == TargetPlatform.macOS) {
               // Getting bad observation result because scrolling in Flutter Web
               // with mouse wheel is not smooth.
               // https://github.com/flutter/flutter/issues/78708

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: scrollview_observer
 description: A widget for observing data related to the child widgets being displayed in a ScrollView.
-version: 1.21.1
+version: 1.21.2
 homepage: https://github.com/fluttercandies/flutter_scrollview_observer
 
 environment:


### PR DESCRIPTION
## Related Issues

- #90 

## Description

See your own rating for web: https://pub.dev/packages/scrollview_observer/score (Platform support)

This PR brings actually web support to flutter_scrollview_observer by updating `observer_widget.dart` not to depend on `dart:io` anymore.

- [x] Web support
- [x] bump version 1.21.2
- [x] changelog entry for 1.21.2