### PR TITLE
ci(assign-issue): grant issues write permission to GITHUB_TOKEN

### DIFF
--- a/.github/workflows/assign-issue.yml
+++ b/.github/workflows/assign-issue.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   auto-assign:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: 'Auto-assign issue'
         uses: pozil/auto-assign-issue@v1


### PR DESCRIPTION
## Description

The `Issue assignment` workflow fails on every newly opened issue:

```
Run pozil/auto-assign-issue@v1
Error: Resource not accessible by integration
```

The default workflow permission of the repository is read-only:

```json
{"default_workflow_permissions": "read", "can_approve_pull_request_reviews": true}
```

`.github/workflows/assign-issue.yml` declares no `permissions` block, so
`GITHUB_TOKEN` is granted read-only access and the action cannot assign the
issue. `deploy.yml` was already given an explicit permission in 562cad4, this
workflow was missed.

Grant the job the single permission it needs:

```yaml
jobs:
  auto-assign:
    runs-on: ubuntu-latest
    permissions:
      issues: write
```

The workflow only triggers on `issues`, so `issues: write` is enough,
`pull-requests: write` is not needed.
