### PR TITLE
ci(workflows): pin actions to hashes and restrict token permissions

### DIFF
--- a/.github/workflows/assign-issue.yml
+++ b/.github/workflows/assign-issue.yml
@@ -4,6 +4,8 @@ on:
   issues:
     types: [opened]
 
+permissions: {}
+
 jobs:
   auto-assign:
     runs-on: ubuntu-latest
@@ -11,7 +13,7 @@ jobs:
       issues: write
     steps:
       - name: 'Auto-assign issue'
-        uses: pozil/auto-assign-issue@v1
+        uses: pozil/auto-assign-issue@65947009a243e6b3993edeef4e64df3ca85d760c # v1.14.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           assignees: LinXunFeng

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -13,12 +13,17 @@ on:
     paths-ignore:
       - '**.md'
 
+permissions:
+  contents: read
+
 jobs:
   code-analysis:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: subosito/flutter-action@v2
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           channel: 'stable'
       - name: Prepare dependencies
@@ -43,8 +48,10 @@ jobs:
       matrix:
         flutter-version: ['']
     steps:
-      - uses: actions/checkout@v4
-      - uses: subosito/flutter-action@v2
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           channel: 'stable'
           flutter-version: ${{ matrix.flutter-version }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - main
       # - develop
+
+permissions: {}
+
 jobs:
   build:
     name: Build Web
@@ -13,8 +16,10 @@ jobs:
       my_secret: ${{secrets.commit_secret}}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: subosito/flutter-action@v2
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           # flutter-version: '3.16.9'
           channel: 'stable'
@@ -25,7 +30,7 @@ jobs:
           flutter pub get
           flutter build web --release --base-href /flutter_scrollview_observer/
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3.9.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./example/build/web


### PR DESCRIPTION
## Related Issues

- https://github.com/fluttercandies/security-scanner/issues/24

## Description

`zizmor` reports 8 high and 6 medium findings on the three workflows. This PR
clears all of them.

**`unpinned-uses` / `ref-confusion`** - every action is referenced by a mutable
tag. Pin them to commit hashes, keeping the version as a trailing comment:

```
actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3.9.3
pozil/auto-assign-issue@65947009a243e6b3993edeef4e64df3ca85d760c # v1.14.0
```

Each one is the latest release of the major version already in use, so no
behaviour changes.

**`excessive-permissions`** - no workflow declares a `permissions` block, so the
jobs fall back to the default token scope. Declare `permissions: {}` at the
workflow level and keep only what each job actually needs: `issues: write` for
assign-issue, `contents: write` for deploy, `contents: read` for code-analysis.

**`artipacked`** - `actions/checkout` persists the token in `.git/config` by
default. None of these workflows push through it, so set
`persist-credentials: false`. The gh-pages deploy authenticates with its own
`github_token` input and is unaffected.

## Verification

Locally with zizmor v1.29.0:

```
before: 25 findings - 8 high, 6 medium
after:  No findings to report. Good job! (9 suppressed)
```

`--persona=pedantic` also reports 0 high and 0 medium. The remaining
informational and low findings there (`concurrency-limits`,
`undocumented-permissions`) are pedantic-only audits and are left alone.
